### PR TITLE
added support for the Swedish locale

### DIFF
--- a/fbchat_archive_parser/time.py
+++ b/fbchat_archive_parser/time.py
@@ -22,6 +22,7 @@ FACEBOOK_TIMESTAMP_FORMATS = [
     ("es_es", "dddd, D [de] MMMM [de] YYYY [a las?] H:mm"),     # Spanish (General)
     ("hu_hu", "YYYY. MMMM D., H:mm"),                           # Hungarian
     ("it_it", "dddd D MMMM YYYY [alle ore] H:mm"),              # Italian (Italy)
+    ("sv_se", "D MMMM YYYY kl HH:mm"),                          # Swedish (Sweden)
 ]
 
 # Generate a mapping of all timezones to their offsets.

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -55,6 +55,10 @@ class TestTimestamps(unittest.TestCase):
     def test_magyar(self):
         timestamp_raw = "2016. december 4., 13:54 UTC-07"
         self.run_timestamp_test(timestamp_raw)
+    
+    def test_swedish(self):
+        timestamp_raw = "den 4 december 2016 kl 13:54 UTC-07"
+        self.run_timestamp_test(timestamp_raw)
 
     def test_bad_timestamp(self):
         timestamp_raw = "not a real timestamp"


### PR DESCRIPTION
This date parsing for Swedish (sv_se) seems to work fine for my fairly extensive message archive.

(Also, thanks for this project! 👌)