### PR TITLE
Fix use of `six` for Python 2

### DIFF
--- a/fbchat_archive_parser/parser.py
+++ b/fbchat_archive_parser/parser.py
@@ -346,7 +346,9 @@ class MessageHtmlParser(object):
                 existing_thread.add_message(m)
 
     def parse_participants(self, participants):
-        if not isinstance(participants, six.text_type):
+        if not participants:
+            return ()
+        if not isinstance(participants, six.string_types):
             if not participants.text:
                 return ()
             if participants.attrib:
@@ -500,7 +502,7 @@ class SplitMessageHtmlWithImagesParser(SplitMessageHtmlParser):
                 else:
                     # Un-escape any HTML entities.
                     import bs4
-                    unescaped = str(bs4.BeautifulSoup(m.group(1), 'html.parser'))
+                    unescaped = six.text_type(bs4.BeautifulSoup(m.group(1), 'html.parser'))
                     participants = self.parse_participants(unescaped)
                 self.process_thread(participants, thread_path)
 


### PR DESCRIPTION
Fixes issue #64. Didn't realize `six.text_type` doesn't detect all text types (i.e. `str` under Python 2) and that `six.string_types` is actually what was needed.