### PR TITLE
Lithuanian language support

### DIFF
--- a/fbchat_archive_parser/time.py
+++ b/fbchat_archive_parser/time.py
@@ -53,6 +53,13 @@ FACEBOOK_TIMESTAMP_FORMATS = [
     ("sr_sr", "D. MMMM YYYY. [у] H:mm"),                        # Serbian (Cyrillic)
     ("fi_fi", "D. MMMM YYYY [kello] H:mm"),                     # Finnish
     ("ru_ru", "D MMMM YYYY [г. в] H:mm"),                       # Russian
+    ("lt_lt", "YYYY [m.] MMMM D [d.,] HH:mm",                   # Lithuanian
+            {'sausis': 1, 'vasaris': 2, 'kovas': 3,
+             'balandis': 4, 'gegužė': 5, 'birželis': 6,
+             'liepa': 7, 'rugpjūtis': 8, 'rugsėjis': 9,
+             'spalis': 10, 'lapkritis': 11, 'gruodis': 12
+             }
+     ),
 ]
 
 

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -114,5 +114,9 @@ class TestTimestamps(unittest.TestCase):
         timestamp_raw = "4 декабря 2016 г. в 13:54 UTC-07"
         self.run_timestamp_test(timestamp_raw)
 
+    def test_lithuanian(self):
+        timestamp_raw = "2016 m. gruodis 4 d., 13:54 UTC-07"
+        self.run_timestamp_test(timestamp_raw)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some months are in nominative case which caused parsing to fail. Adding those to 'hints' fixes the problem. Test case is also provided.