### PR TITLE
Add support for Slovak, fixes #80

### DIFF
--- a/fbchat_archive_parser/time.py
+++ b/fbchat_archive_parser/time.py
@@ -46,6 +46,7 @@ FACEBOOK_TIMESTAMP_FORMATS = [
     ("ro_ro", "D MMMM YYYY [la] HH:mm"),                        # Romanian (Romania)
     ("sl_si", "D. MMMM YYYY [ob] H:mm"),                        # Slovenian
     ("cs_cz", "D. MMMM YYYY [v] H:mm"),                         # Czech
+    ("sk_sk", "D. MMMM YYYY, H:mm"),                            # Slovak
     ("pt_br", "D [de] MMMM [de] YYYY [às] HH:mm"),              # Portuguese (Brazil)
     ("pt_pt", "dddd, D [de] MMMM [de] YYYY [às] HH:mm"),        # Portuguese (Portugal)
     ("pl_pl", "D MMMM YYYY [o] HH:mm"),                         # Polish

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -80,6 +80,10 @@ class TestTimestamps(unittest.TestCase):
         timestamp_raw = "4. prosinec 2016 v 13:54 UTC-07"
         self.run_timestamp_test(timestamp_raw)
 
+    def test_slovak(self):
+        timestamp_raw = "5. december 2017, 9:02 UTC+01"
+        self.run_timestamp_test(timestamp_raw)
+
     def test_portuguese_brazil(self):
         timestamp_raw = "4 de dezembro de 2016 às 13:54 UTC-07"
         self.run_timestamp_test(timestamp_raw)


### PR DESCRIPTION
Parked right under the Czech entry, since they’re really similar.

Note that I’m not 100% sure I did this right but it parsed my archive well enough to show me the statistics, so I guess it works.